### PR TITLE
Fix to return exit code 1 when exception is thrown on tests with tape@>=3

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -9,11 +9,12 @@ var tap = parser();
 var dup = duplexer(tap, out);
 var currentTestName = '';
 var errors = [];
+var passed = false;
 var Nyan = require('./nyan');
 var nyan = new Nyan(out);
 nyan.cursor.hide();
 tap.on('comment', function (comment) {
-  currentTestName = comment;
+  currentTestName = comment.replace('# ', '').trim();
 });
 tap.on('assert', function (res) {
   if (res.ok) {
@@ -25,25 +26,21 @@ tap.on('assert', function (res) {
 
 });
 
-// tap.on('extra', function (extra) {
-//   out.push('   ' + extra + '\n');
-// });
-
-tap.on('results', function (res) {
-  nyan.cursor.show();
+tap.on('complete', function (res) {
   out.push('\n\n\n\n');
-  if (errors.length) {
+  if (errors.length || !res.ok) {
     var past = (errors.length == 1) ? 'was' : 'were';
     var plural = (errors.length == 1) ? 'failure' : 'failures';
-    
+
     out.push('  ' + chalk.red('Failed Tests: '));
     out.push('There ' + past + ' ' + chalk.red(errors.length) + ' ' + plural + '\n\n');
-    
+
     errors.forEach(function (error) {
       out.push('    ' + chalk.red('✗') + ' ' + chalk.red(error) + '\n');
     });
   }
   else{
+    passed = true;
     out.push('  ' + chalk.green('Pass!') + '\n');
   }
 });
@@ -51,9 +48,10 @@ tap.on('results', function (res) {
 process.stdin
   .pipe(dup)
   .pipe(process.stdout);
-  
+
 process.on('exit', function () {
-  if (errors.length) {
+  nyan.cursor.show();
+  if (errors.length || !passed) {
     process.exit(1);
   }
 });

--- a/package.json
+++ b/package.json
@@ -21,16 +21,16 @@
     "url": "https://github.com/calvinmetcalf/tap-nyan/issues"
   },
   "dependencies": {
-    "chalk": "~0.4.0",
-    "through2": "~0.2.3",
-    "tap-parser": "~0.4.1",
-    "duplexer": "~0.1.1"
+    "chalk": "^1.1.1",
+    "duplexer": "~0.1.1",
+    "tap-parser": "^1.2.2",
+    "through2": "^2.0.1"
   },
   "bin": {
     "tnyan": "bin/cmd.js",
     "tap-nyan": "bin/cmd.js"
   },
   "devDependencies": {
-    "tape": "^2.12.0"
+    "tape": "^4.5.1"
   }
 }


### PR DESCRIPTION
[tape](https://github.com/substack/tape) no longer intercepts exceptions since v3.0.0. (https://github.com/substack/tape/pull/103)


Now *test-w-err.js*,

```javascript
require('tape')('exception', function(t) {
  t.ok(true)
  throw new Error()
  t.ok(true)
  t.end()
})
```

resutls of running

```
node test-w-err.js | node_modules/.bin/tap-nyan; echo exit code $?
```

with each-version tape are following.


### w/ tape@2.14.1

```
 1   -__,------,
 1   -__|  /\_/\ 
 0   -_~|_( x .x) 
     -_ ""  "" 
  Failed Tests: There was 1 failure

    ✗ exception: Error
exit code 1
```


### w/ tape@4.5.1

```
 1   -_,------,
 0   -_|   /\_/\ 
 0   -^|__( ^ .^) 
     -  ""  "" 
  Pass!
exit code 0
```

A result of above, with exit code `0`, is not ideal, I think.


With my fix, results will change to follwing.

### fixed w/ tape@2.14.1

```
 1   -__,------,
 1   -__|  /\_/\ 
 0   -_~|_( x .x) 
     -_ ""  "" 
  Failed Tests: There was 1 failure

    ✗ exception: Error
exit code 1
```


#### fixed w/ tape@4.5.1

```
/home/keik/tmp/nyan-p-t4/test-w-err.js:4
  throw new Error()
  ^

Error
    at Test.<anonymous> (/home/keik/tmp/nyan-p-t4/test-w-err.js:4:9)
    at Test.bound [as _cb] (/home/keik/tmp/nyan-p-t4/node_modules/tape/lib/test.js:61:32)
    at Test.run (/home/keik/tmp/nyan-p-t4/node_modules/tape/lib/test.js:80:10)
    at Test.bound [as run] (/home/keik/tmp/nyan-p-t4/node_modules/tape/lib/test.js:61:32)
    at Immediate.next [as _onImmediate] (/home/keik/tmp/nyan-p-t4/node_modules/tape/lib/results.js:70:15)
    at processImmediate [as _immediateCallback] (timers.js:383:17)
 1   -_,------,
 0   -_|   /\_/\ 
 0   -^|__( ^ .^) 
     -  ""  "" 
  Failed Tests: There were 0 failures

exit code 1
```