### PR TITLE
Separate stream reporter into separate file, so it can be used in script

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,59 +1,13 @@
 #!/usr/bin/env node
 
-var through = require('through2');
-var parser = require('tap-parser');
-var duplexer = require('duplexer');
-var chalk = require('chalk');
-var out = through();
-var tap = parser();
-var dup = duplexer(tap, out);
-var currentTestName = '';
-var errors = [];
-var Nyan = require('./nyan');
-var nyan = new Nyan(out);
-nyan.cursor.hide();
-tap.on('comment', function (comment) {
-  currentTestName = comment;
-});
-tap.on('assert', function (res) {
-  if (res.ok) {
-    nyan.pass();
-  } else {
-    nyan.fail();
-    errors.push(currentTestName + ': ' + res.name);
-  }
-
-});
-
-// tap.on('extra', function (extra) {
-//   out.push('   ' + extra + '\n');
-// });
-
-tap.on('results', function (res) {
-  nyan.cursor.show();
-  out.push('\n\n\n\n');
-  if (errors.length) {
-    var past = (errors.length == 1) ? 'was' : 'were';
-    var plural = (errors.length == 1) ? 'failure' : 'failures';
-    
-    out.push('  ' + chalk.red('Failed Tests: '));
-    out.push('There ' + past + ' ' + chalk.red(errors.length) + ' ' + plural + '\n\n');
-    
-    errors.forEach(function (error) {
-      out.push('    ' + chalk.red('✗') + ' ' + chalk.red(error) + '\n');
-    });
-  }
-  else{
-    out.push('  ' + chalk.green('Pass!') + '\n');
-  }
-});
+var tapNyan = require('../')();
 
 process.stdin
-  .pipe(dup)
+  .pipe(tapNyan())
   .pipe(process.stdout);
-  
-process.on('exit', function () {
-  if (errors.length) {
+
+process.on('exit', function(status) {
+  if(status === 1 || tapNyan.failed) {
     process.exit(1);
   }
 });

--- a/index.js
+++ b/index.js
@@ -1,0 +1,66 @@
+var through = require('through2');
+var parser = require('tap-parser');
+var duplexer = require('duplexer');
+var chalk = require('chalk');
+
+var Nyan = require('./bin/nyan');
+
+module.exports = function NyanReporter() {
+  var out = through();
+  var tap = parser();
+  var stream = duplexer(tap, out);
+  var nyan = new Nyan(out);
+
+  var currentTestName = '';
+  var errors = [];
+
+  nyan.cursor.hide();
+
+  function markFailed() { stream.failed = true; }
+
+  tap.on('comment', function(comment) {
+    currentTestName = comment;
+  });
+
+  tap.on('assert', function(res) {
+    if(res.ok) {
+      nyan.pass();
+    } else {
+      nyan.fail();
+      errors.push(currentTestName + ': ' + res.name);
+      markFailed();
+    }
+  });
+
+  // tap.on('extra', function (extra) {
+  //   out.push('   ' + extra + '\n');
+  // });
+
+  tap.on('complete', function(res) {
+    nyan.cursor.show();
+    out.push('\n\n\n\n');
+
+    // Most likely a failure upstream
+    if(res.plan.end < 1) {
+      return markFailed();
+    }
+
+    if(errors.length) {
+      markFailed();
+
+      var past = (errors.length === 1) ? 'was' : 'were';
+      var plural = (errors.length === 1) ? 'failure' : 'failures';
+
+      out.push('  ' + chalk.red('Failed Tests: '));
+      out.push('There ' + past + ' ' + chalk.red(errors.length) + ' ' + plural + '\n\n');
+
+      errors.forEach(function(error) {
+        out.push('    ' + chalk.red('✗') + ' ' + chalk.red(error) + '\n');
+      });
+    } else {
+      out.push('  ' + chalk.green('Pass!') + '\n');
+    }
+  });
+
+  return stream;
+};

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "url": "https://github.com/calvinmetcalf/tap-nyan/issues"
   },
   "dependencies": {
-    "chalk": "~0.4.0",
-    "through2": "~0.2.3",
-    "tap-parser": "~0.4.1",
-    "duplexer": "~0.1.1"
+    "chalk": "^1.1.3",
+    "duplexer": "^0.1.1",
+    "tap-parser": "^3.0.3",
+    "through2": "^2.0.1"
   },
   "bin": {
     "tnyan": "bin/cmd.js",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "test": "node test/test.js | ./bin/cmd.js"
   },
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/calvinmetcalf/tap-nyan.git"

--- a/test/test.js
+++ b/test/test.js
@@ -2,24 +2,23 @@ var tape = require('tape');
 
 
 function runTest(name) {
-  tape('test ' + name, function (t){
+  tape('test ' + name, function(t) {
     t.plan(9);
     t.ok('success');
-    t.equals(1,1, 'are equal');
-    t.equals(1,1, 'are equal');
-    t.equals(1,1, 'are equal');
-    t.equals(1,1, 'are equal');
-    t.equals(1,1, 'are equal');
-    t.equals(1,1, 'are equal');
-    t.equals(1,1, 'are equal');
-    setTimeout(function () {
+    t.equals(1, 1, 'are equal');
+    t.equals(1, 1, 'are equal');
+    t.equals(1, 1, 'are equal');
+    t.equals(1, 1, 'are equal');
+    t.equals(1, 1, 'are equal');
+    t.equals(1, 1, 'are equal');
+    t.equals(1, 1, 'are equal');
+    setTimeout(function() {
       t.ok(true, name + ' should be less then 83');
     }, 50);
-    
   });
 }
 
 var i = 50;
-while(i++<100) {
+while(i++ < 100) {
   runTest(i);
 }


### PR DESCRIPTION
Hi

I wanted to use the reporter from a script, but since it was only build to be used in the CLI I took the liberty to separate the reporter script into a separate file that could in turn be used from a script like so:

```js
var tapNyan = require('tap-nyan')
test.createStrem()
  .pipe(tapNyan())
  .pipe(process.stdout);
```

While doing so I also updated the dependencies to the latest version